### PR TITLE
deps: remove prettier-plugin-multiline-arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,136 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "prettier-plugin-jsdoc": "^1.3.2",
-        "prettier-plugin-multiline-arrays": "^4.0.3",
         "prettier-plugin-packagejson": "^2.5.10"
       },
       "devDependencies": {
         "eslint": "^9.23.0",
         "neostandard": "^0.12.1",
         "prettier": "^3.5.3"
-      }
-    },
-    "node_modules/@augment-vir/assert": {
-      "version": "31.11.0",
-      "resolved": "https://registry.npmjs.org/@augment-vir/assert/-/assert-31.11.0.tgz",
-      "integrity": "sha512-+MImbmykxgqtwrljlF3ucbW0CXc3oJXrJpVQhCFf3xu07CV+FvRcq/iofhoR5ZiwfsYLzGlg+2oxDOAxSIn1zQ==",
-      "license": "(MIT or CC0 1.0)",
-      "dependencies": {
-        "@augment-vir/core": "^31.11.0",
-        "@date-vir/duration": "^7.3.1",
-        "deep-eql": "^5.0.2",
-        "expect-type": "^1.2.1",
-        "type-fest": "^4.39.1"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@augment-vir/assert/node_modules/type-fest": {
-      "version": "4.39.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
-      "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@augment-vir/common": {
-      "version": "31.11.0",
-      "resolved": "https://registry.npmjs.org/@augment-vir/common/-/common-31.11.0.tgz",
-      "integrity": "sha512-aOhzXHYxk1BVLmxrSoW3SdXWV5Wo1g7y8WeYsZN4AbTHri3Fryv8kI6DXWD/mVxKqWswxmwoW7PiAqO5sXV+oA==",
-      "license": "(MIT or CC0 1.0)",
-      "dependencies": {
-        "@augment-vir/assert": "^31.11.0",
-        "@augment-vir/core": "^31.11.0",
-        "@date-vir/duration": "^7.3.1",
-        "ansi-styles": "^6.2.1",
-        "json5": "^2.2.3",
-        "type-fest": "^4.39.1",
-        "typed-event-target": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@augment-vir/common/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@augment-vir/common/node_modules/type-fest": {
-      "version": "4.39.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
-      "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@augment-vir/core": {
-      "version": "31.11.0",
-      "resolved": "https://registry.npmjs.org/@augment-vir/core/-/core-31.11.0.tgz",
-      "integrity": "sha512-bK2aAifOQfuha5L4FYkP2b8KWEACvAB9dC8TBjNKqQMo59DQSsiWTBGoYcTpSv7tBwBEteDQFYKdGsl7ODYZEw==",
-      "license": "(MIT or CC0 1.0)",
-      "dependencies": {
-        "@date-vir/duration": "^7.3.1",
-        "browser-or-node": "^3.0.0",
-        "json5": "^2.2.3",
-        "type-fest": "^4.39.1"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@augment-vir/core/node_modules/type-fest": {
-      "version": "4.39.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
-      "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@date-vir/duration": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@date-vir/duration/-/duration-7.3.1.tgz",
-      "integrity": "sha512-MRXg2dz021QdOYx4TRcDFJ1PhiNIr8HsZ73uFot5+yMbE0oMdqEDpetzm3PAYvSrYrC3L/qxr8+cnh6FUr+cRw==",
-      "license": "(MIT or CC0 1.0)",
-      "dependencies": {
-        "@types/luxon": "^3.4.2",
-        "luxon": "^3.5.0",
-        "type-fest": "^4.37.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@date-vir/duration/node_modules/type-fest": {
-      "version": "4.39.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
-      "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@emnapi/core": {
@@ -537,12 +413,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/luxon": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
-      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
@@ -1261,12 +1131,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/browser-or-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-3.0.0.tgz",
-      "integrity": "sha512-iczIdVJzGEYhP5DqQxYM9Hh7Ztpqqi+CXZpSmX8ALFs9ecXkQIeqRyM6TfxEfMVpwhl3dSuDvxdzzo9sUOIVBQ==",
-      "license": "MIT"
-    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -1487,15 +1351,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2276,15 +2131,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expect-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
-      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3263,18 +3109,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -3349,15 +3183,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
-      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4244,22 +4069,6 @@
         "prettier": "^3.0.0"
       }
     },
-    "node_modules/prettier-plugin-multiline-arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-multiline-arrays/-/prettier-plugin-multiline-arrays-4.0.3.tgz",
-      "integrity": "sha512-H1f/0zbvlO/FR0Fmyl31sSBodsIZkuQF0Omi9BrptLU31rZ+Almt9BbrE8IS3BFT/DGKePKb55XqN660LTnmsQ==",
-      "license": "(MIT or CC0 1.0)",
-      "dependencies": {
-        "@augment-vir/common": "^31.10.1",
-        "proxy-vir": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "prettier": ">=3.0.0"
-      }
-    },
     "node_modules/prettier-plugin-packagejson": {
       "version": "2.5.10",
       "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.10.tgz",
@@ -4288,19 +4097,6 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/proxy-vir": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/proxy-vir/-/proxy-vir-2.0.1.tgz",
-      "integrity": "sha512-hjy5mWzHZhgRGh0f90f0Bz3VrGUe0T+AlhwnETakzRdvaN9RtPYLQG1+ZuEzSDK95FAhPYd26nEi1xVrXqvBwg==",
-      "license": "(MIT or CC0 1.0)",
-      "dependencies": {
-        "@augment-vir/assert": "^31.1.0",
-        "@augment-vir/common": "^31.1.0"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/punycode": {
@@ -5020,20 +4816,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-event-target": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typed-event-target/-/typed-event-target-4.0.3.tgz",
-      "integrity": "sha512-CwpGF+ne1ju2zZo9Cx1VCG6fWQkcV8Mu1cFH2i4hciiuch3u6GahNirkfOE+S+9cegZ5NKvyR7gCXedJbV5uvQ==",
-      "license": "(MIT or CC0 1.0)",
-      "dependencies": {
-        "@augment-vir/assert": "^31.9.3",
-        "@augment-vir/common": "^31.9.3",
-        "@augment-vir/core": "^31.9.3"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "prettier": ".",
   "dependencies": {
     "prettier-plugin-jsdoc": "^1.3.2",
-    "prettier-plugin-multiline-arrays": "^4.0.3",
     "prettier-plugin-packagejson": "^2.5.10"
   },
   "devDependencies": {


### PR DESCRIPTION
We decided to not use prettier-plugin-multiline-arrays, but forgot to remove it from dependencies.

Parent issue:
- https://github.com/CheckerNetwork/roadmap/issues/166