### PR TITLE
chore: add dummy test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "scripts": {
     "lint": "eslint && prettier --check .",
-    "lint:fix": "eslint --fix && prettier --write ."
+    "lint:fix": "eslint --fix && prettier --write .",
+    "test": "npm run lint"
   },
   "prettier": ".",
   "dependencies": {


### PR DESCRIPTION
Add `npm test` as an alias for `npm run lint`. With no tests, `npx np` fails with the following error:

```
  ✖ Running tests
    → Command failed with exit code 1: npm run test
    Bumping version
```

Alternative considered: update the instructions to `npx np --no-tests`. I decided against this option due to the extra friction it adds.
